### PR TITLE
Handle previously uncaught exception

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/reader/activity/TroubleCodesActivity.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/activity/TroubleCodesActivity.java
@@ -31,6 +31,7 @@ import pt.lighthouselabs.obd.commands.control.TroubleCodesObdCommand;
 import pt.lighthouselabs.obd.enums.ObdProtocols;
 import pt.lighthouselabs.obd.reader.R;
 import pt.lighthouselabs.obd.exceptions.UnableToConnectException;
+import pt.lighthouselabs.obd.exceptions.MisunderstoodCommandException;
 
 public class TroubleCodesActivity extends Activity {
 
@@ -225,6 +226,10 @@ public class TroubleCodesActivity extends Activity {
           mHandler.obtainMessage(OBD_COMMAND_FAILURE).sendToTarget();
           return null;
         } catch (UnableToConnectException e) {
+          e.printStackTrace();
+          mHandler.obtainMessage(OBD_COMMAND_FAILURE).sendToTarget();
+          return null;
+        } catch (MisunderstoodCommandException e) {
           e.printStackTrace();
           mHandler.obtainMessage(OBD_COMMAND_FAILURE).sendToTarget();
           return null;


### PR DESCRIPTION
MisunderstoodCommandException can happen when communication with the obd device gets out of sync.  Catch the exception to prevent obd-reader from crashing.
